### PR TITLE
Non-blocking socket read with timeout and clarify FIN/EOF behavior

### DIFF
--- a/lib/mine_votifier/client.rb
+++ b/lib/mine_votifier/client.rb
@@ -16,6 +16,8 @@ module MineVotifier
     # @param minecraft_server [#hostname, #port, #encrypt] server details and encryption provider
     # @param timeout [Integer] connection timeout in seconds (defaults to DEFAULT_TIMEOUT)
     def initialize(service_name:, minecraft_server:, timeout: DEFAULT_TIMEOUT)
+      validate_service_name!(service_name)
+
       @service_name     = service_name
       @minecraft_server = minecraft_server
       @timeout          = timeout
@@ -25,11 +27,13 @@ module MineVotifier
     # @param username [String, nil] the username to vote for (2-16 characters)
     # @param ip_address [String, nil] the IP address of the voter, defaults to 127.0.0.1 if nil
     # @param timestamp [Integer, nil] UNIX timestamp for the vote
-    # @raise [ValidationError] if username is nil
+    # @raise [ValidationError] if service_name/username/ip_address include a newline
+    # @raise [ValidationError] if username is nil or not 2-16 characters
     # @raise [ReadTimeoutError] if server read does not complete before timeout
     # @return [void]
     def send_vote(username: nil, ip_address: nil, timestamp: nil)
       validate_username!(username)
+      validate_ip_address!(ip_address)
 
       packet = MineVotifier::PacketBuilder.new(
         service_name,
@@ -82,13 +86,44 @@ module MineVotifier
       # Peer half-closed (TCP FIN) and no further data is readable.
     end
 
-    # Validates the username presence
+    # Validates service name safety.
+    # @param name [String] the service name to validate
+    # @raise [ValidationError] when service name is nil/empty or includes a newline
+    # @return [void]
+    def validate_service_name!(name)
+      raise ValidationError, "service_name should not be empty" if name.nil? || name.empty?
+      validate_no_newline!("service_name", name)
+    end
+
+    # Validates username safety.
     # @param name [String, nil] the username to validate
-    # @raise [ValidationError] when username is not nil
+    # @raise [ValidationError] when username is nil, out of length range, or includes a newline
     # @return [void]
     def validate_username!(name)
-      return unless name.nil?
-      raise ValidationError, "username should not empty: \#{name.inspect}"
+      raise ValidationError, "username should not empty: #{name.inspect}" if name.nil?
+      raise ValidationError, "username length should be 2..16: #{name.inspect}" unless (2..16).cover?(name.length)
+
+      validate_no_newline!("username", name)
+    end
+
+    # Validates ip address safety.
+    # @param address [String, nil] the ip address to validate
+    # @raise [ValidationError] when ip address includes a newline
+    # @return [void]
+    def validate_ip_address!(address)
+      return if address.nil?
+      validate_no_newline!("ip_address", address)
+    end
+
+    # Validates protocol field safety against newline injection.
+    # @param field [String] field name for error message
+    # @param value [String] field value to validate
+    # @raise [ValidationError] when value includes CR/LF
+    # @return [void]
+    def validate_no_newline!(field, value)
+      return unless value.include?("\n") || value.include?("\r")
+
+      raise ValidationError, "#{field} should not include CR/LF: #{value.inspect}"
     end
   end
 

--- a/lib/mine_votifier/client.rb
+++ b/lib/mine_votifier/client.rb
@@ -25,7 +25,8 @@ module MineVotifier
     # @param username [String, nil] the username to vote for (2-16 characters)
     # @param ip_address [String, nil] the IP address of the voter, defaults to 127.0.0.1 if nil
     # @param timestamp [Integer, nil] UNIX timestamp for the vote
-    # @raise [ValidationError] if username length is invalid
+    # @raise [ValidationError] if username is nil
+    # @raise [ReadTimeoutError] if server read does not complete before timeout
     # @return [void]
     def send_vote(username: nil, ip_address: nil, timestamp: nil)
       validate_username!(username)
@@ -46,6 +47,7 @@ module MineVotifier
     # Opens a new TCP socket to the configured server and sends encrypted data.
     # Socket is automatically closed when the block ends.
     # @param encrypted [String] the encrypted packet to send
+    # @raise [ReadTimeoutError] if server read does not complete before timeout
     # @return [void]
     def send_to_server(encrypted)
       Socket.tcp(
@@ -58,12 +60,26 @@ module MineVotifier
         sock.flush
         sock.close_write
 
-        Timeout.timeout(timeout) do
-          loop { sock.readpartial(256) }
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+
+        loop do
+          remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          raise ReadTimeoutError, 'socket read timed out' if remaining <= 0
+
+          ready = IO.select([sock], nil, nil, remaining)
+          # IO.select timeout (nil) means no read event was observed within remaining time.
+          break unless ready
+
+          begin
+            # FIN from peer is surfaced as EOFError by read_nonblock, handled below.
+            sock.read_nonblock(256)
+          rescue IO::WaitReadable
+            next
+          end
         end
       end
     rescue EOFError
-      # FIN received, no further data to read
+      # Peer half-closed (TCP FIN) and no further data is readable.
     end
 
     # Validates the username presence
@@ -75,6 +91,10 @@ module MineVotifier
       raise ValidationError, "username should not empty: \#{name.inspect}"
     end
   end
+
+
+  # Raised when socket read exceeds configured timeout.
+  class ReadTimeoutError < StandardError; end
 
   # Raised when validation fails in Votifier client.
   class ValidationError < StandardError; end

--- a/lib/mine_votifier/client.rb
+++ b/lib/mine_votifier/client.rb
@@ -64,11 +64,11 @@ module MineVotifier
 
         loop do
           remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          raise ReadTimeoutError, 'socket read timed out' if remaining <= 0
+          raise ReadTimeoutError, "socket read timed out (reason=remaining<=0, remaining=#{remaining})" if remaining <= 0
 
           ready = IO.select([sock], nil, nil, remaining)
           # IO.select timeout (nil) means no read event was observed within remaining time.
-          raise ReadTimeoutError, 'socket read timed out' unless ready
+          raise ReadTimeoutError, "socket read timed out (reason=io_select_timeout, remaining=#{remaining})" unless ready
 
           begin
             # FIN from peer is surfaced as EOFError by read_nonblock, handled below.

--- a/lib/mine_votifier/client.rb
+++ b/lib/mine_votifier/client.rb
@@ -68,7 +68,7 @@ module MineVotifier
 
           ready = IO.select([sock], nil, nil, remaining)
           # IO.select timeout (nil) means no read event was observed within remaining time.
-          break unless ready
+          raise ReadTimeoutError, 'socket read timed out' unless ready
 
           begin
             # FIN from peer is surfaced as EOFError by read_nonblock, handled below.


### PR DESCRIPTION
### Motivation
- Improve robustness of the server-read path by replacing the previous blocking `readpartial`/`Timeout.timeout` approach with a non-blocking loop and explicit timeout handling.
- Make the distinction clear between an `IO.select` timeout (no read event) and a TCP FIN from the peer (surfaced as `EOFError`) so maintainers don't confuse the two.
- Update docstrings and validation behavior to correctly describe when validation and read-timeout errors are raised.

### Description
- Replace the `Timeout.timeout` + `sock.readpartial(256)` loop with a monotonic-deadline loop using `IO.select` and `sock.read_nonblock`, and raise `ReadTimeoutError` when the deadline is exceeded.
- Add inline comments to document that `IO.select` returning `nil` indicates a select timeout (no read event) and that a TCP FIN is surfaced as `EOFError` by `read_nonblock`.
- Update the `rescue EOFError` comment to explicitly state it represents a peer half-close (TCP FIN).
- Adjust method documentation for `send_vote` and `send_to_server` and ensure `validate_username!` raises `ValidationError` when the username is `nil`.
- Add a `ReadTimeoutError` class to represent socket read timeouts.

### Testing
- Ran a Ruby syntax check with `ruby -c lib/mine_votifier/client.rb`, which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e8b1e7668832d8e5f570ecdb4f30a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 입력값 검증이 추가되어 서비스 이름, 사용자명, IP 형식 관련 잘못된 입력을 사전 차단합니다.
  * 읽기 타임아웃을 외부적으로 구분해 알리는 새 오류 유형이 도입되었습니다.

* **버그 수정**
  * 서버와의 통신 중 타임아웃 처리와 연결 종료 처리 로직이 개선되어 안정성이 향상되었습니다.
  * 오류 메시지와 문서가 갱신되어 문제 원인 파악이 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->