### PR TITLE
Relax username validation to max-length only

### DIFF
--- a/lib/mine_votifier/client.rb
+++ b/lib/mine_votifier/client.rb
@@ -24,11 +24,11 @@ module MineVotifier
     end
 
     # Sends a vote packet encrypted via the MinecraftServer and over TCP.
-    # @param username [String, nil] the username to vote for (2-16 characters)
+    # @param username [String, nil] the username to vote for (up to 16 characters)
     # @param ip_address [String, nil] the IP address of the voter, defaults to 127.0.0.1 if nil
     # @param timestamp [Integer, nil] UNIX timestamp for the vote
     # @raise [ValidationError] if service_name/username/ip_address include a newline
-    # @raise [ValidationError] if username is nil or not 2-16 characters
+    # @raise [ValidationError] if username is nil or longer than 16 characters
     # @raise [ReadTimeoutError] if server read does not complete before timeout
     # @return [void]
     def send_vote(username: nil, ip_address: nil, timestamp: nil)
@@ -97,11 +97,11 @@ module MineVotifier
 
     # Validates username safety.
     # @param name [String, nil] the username to validate
-    # @raise [ValidationError] when username is nil, out of length range, or includes a newline
+    # @raise [ValidationError] when username is nil, longer than 16 characters, or includes a newline
     # @return [void]
     def validate_username!(name)
       raise ValidationError, "username should not empty: #{name.inspect}" if name.nil?
-      raise ValidationError, "username length should be 2..16: #{name.inspect}" unless (2..16).cover?(name.length)
+      raise ValidationError, "username length should be <=16: #{name.inspect}" if name.length > 16
 
       validate_no_newline!("username", name)
     end

--- a/test/test_votifier_client_validation.rb
+++ b/test/test_votifier_client_validation.rb
@@ -47,4 +47,28 @@ class VotifierClientValidationTest < Test::Unit::TestCase
       client.send_vote(username: 'Notch', ip_address: '127.0.0.1')
     end
   end
+
+  def test_single_character_username_is_valid
+    client = build_client
+
+    assert_nothing_raised do
+      client.send_vote(username: 'N')
+    end
+  end
+
+  def test_empty_username_is_valid
+    client = build_client
+
+    assert_nothing_raised do
+      client.send_vote(username: '')
+    end
+  end
+
+  def test_username_longer_than_16_characters_raises_validation_error
+    client = build_client
+
+    assert_raise(MineVotifier::ValidationError) do
+      client.send_vote(username: 'a' * 17)
+    end
+  end
 end


### PR DESCRIPTION
### Motivation
- Remove the minimum-length requirement for usernames so nicknames of any (non-nil) length up to 16 characters are accepted.
- Preserve the existing `nil` rejection and newline injection protections.
- Update documentation comments to reflect the new rule and add tests to cover the changed behavior.

### Description
- Update `validate_username!` in `lib/mine_votifier/client.rb` to only enforce `name.length <= 16` and drop the previous `2..16` range check, while still rejecting `nil` and CR/LF (`validate_no_newline!`).
- Update method and parameter doc comments in `lib/mine_votifier/client.rb` to state the new "up to 16 characters" rule and adjust `@raise` text.
- Add new tests in `test/test_votifier_client_validation.rb` to assert that a single-character username and an empty string are valid and that a 17-character username raises `MineVotifier::ValidationError`.

### Testing
- Ran `ruby -Ilib -Itest test/test_votifier_client_validation.rb` which passed: `7 tests, 7 assertions, 0 failures`.
- Ran `ruby -Ilib -Itest -e 'Dir["test/test_*.rb"].sort.each { |f| require_relative f }'` which showed unrelated failures in `test/test_votifer_client.rb` due to an existing `MiniTest` constant issue (3 errors), not caused by this change.
- Attempted `bundle exec ruby -Itest test/test_votifier_client_validation.rb` but `bundle exec` could not run due to missing `Gemfile` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ed5e93408832d92cc11782bc1e7b0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 사용자명 검증 규칙을 수정했습니다. 이제 최소 1글자 이상 최대 16글자 이하의 사용자명이 허용됩니다.

* **테스트**
  * 사용자명 검증을 위한 추가 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->