### PR TITLE
Relax username validation to string-only check

### DIFF
--- a/lib/mine_votifier/client.rb
+++ b/lib/mine_votifier/client.rb
@@ -24,11 +24,11 @@ module MineVotifier
     end
 
     # Sends a vote packet encrypted via the MinecraftServer and over TCP.
-    # @param username [String, nil] the username to vote for (2-16 characters)
+    # @param username [String, nil] the username to vote for
     # @param ip_address [String, nil] the IP address of the voter, defaults to 127.0.0.1 if nil
     # @param timestamp [Integer, nil] UNIX timestamp for the vote
     # @raise [ValidationError] if service_name/username/ip_address include a newline
-    # @raise [ValidationError] if username is nil or not 2-16 characters
+    # @raise [ValidationError] if username is not a String
     # @raise [ReadTimeoutError] if server read does not complete before timeout
     # @return [void]
     def send_vote(username: nil, ip_address: nil, timestamp: nil)
@@ -97,11 +97,12 @@ module MineVotifier
 
     # Validates username safety.
     # @param name [String, nil] the username to validate
-    # @raise [ValidationError] when username is nil, out of length range, or includes a newline
+    # @raise [ValidationError] when username is not a String or includes a newline
     # @return [void]
     def validate_username!(name)
-      raise ValidationError, "username should not empty: #{name.inspect}" if name.nil?
-      raise ValidationError, "username length should be 2..16: #{name.inspect}" unless (2..16).cover?(name.length)
+      unless name.is_a?(String)
+        raise ValidationError, "username should be String: #{name.inspect}"
+      end
 
       validate_no_newline!("username", name)
     end

--- a/test/test_votifier_client_validation.rb
+++ b/test/test_votifier_client_validation.rb
@@ -24,6 +24,30 @@ class VotifierClientValidationTest < Test::Unit::TestCase
     end
   end
 
+  def test_non_string_username_raises_validation_error
+    client = build_client
+
+    assert_raise(MineVotifier::ValidationError) do
+      client.send_vote(username: 1234, ip_address: '127.0.0.1')
+    end
+  end
+
+  def test_short_username_string_is_valid
+    client = build_client
+
+    assert_nothing_raised do
+      client.send_vote(username: 'A', ip_address: '127.0.0.1')
+    end
+  end
+
+  def test_long_username_string_is_valid
+    client = build_client
+
+    assert_nothing_raised do
+      client.send_vote(username: 'A' * 64, ip_address: '127.0.0.1')
+    end
+  end
+
   def test_ip_address_with_newline_raises_validation_error
     client = build_client
 


### PR DESCRIPTION
### Motivation
- The username validation previously enforced a hard length constraint (2..16) which should be removed so only type and newline safety are enforced.
- The goal is to accept any String username while still preventing CR/LF injection and rejecting non-string values.

### Description
- Remove the length and nil checks from `MineVotifier::Client#validate_username!` and replace them with a type check that raises when the username is not a `String`.
- Preserve newline (CR/LF) validation by keeping the existing `validate_no_newline!` call for usernames.
- Update YARD comments in `lib/mine_votifier/client.rb` to reflect the new validation behavior.
- Add tests in `test/test_votifier_client_validation.rb` to assert non-string usernames raise `ValidationError` and that very short and very long strings are accepted.

### Testing
- Ran `ruby -Ilib -Itest test/test_votifier_client_validation.rb`, which executed 7 tests and all passed (7 tests, 7 assertions, 0 failures, 0 errors).
- Attempted to run the full test suite with `ruby -Ilib -Itest -e 'Dir["test/test_*.rb"].sort.each { |f| require_relative f }'`, which produced 3 errors unrelated to this change due to an existing `MiniTest` constant issue in `test/test_votifer_client.rb`, resulting in 31 tests run with 0 failures and 3 errors (90.32% passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ed877b510832dad74bea628a2b945)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 사용자명 길이 제한 요구사항이 문서에서 제거되었습니다.

* **버그 수정**
  * 사용자명 검증 로직을 개선하여 이제 문자열 유형 확인만 수행합니다.

* **테스트**
  * 사용자명 유형 검증 및 다양한 길이의 사용자명을 처리하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->